### PR TITLE
Monk: Add Monk Kit on master branch

### DIFF
--- a/Dockerfile.static-frontend
+++ b/Dockerfile.static-frontend
@@ -1,0 +1,3 @@
+FROM nginx:alpine
+COPY . /usr/share/nginx/html
+EXPOSE 80

--- a/MANIFEST
+++ b/MANIFEST
@@ -1,0 +1,2 @@
+REPO pink
+LOAD monk.yaml

--- a/monk.yaml
+++ b/monk.yaml
@@ -1,0 +1,30 @@
+namespace: pink
+
+static-frontend:
+  defines: runnable
+  metadata:
+    name: static-frontend
+    description: >-
+      A static frontend website that can be served using a web server like
+      nginx.
+    icon: https://emojiapi.dev/api/v1/robot.svg
+  containers:
+    static-frontend:
+      image: env-3531.registry.local/static-frontend:master-1f62652
+      build: .
+      dockerfile: Dockerfile.static-frontend
+  services:
+    http:
+      description: Standard HTTP port for web traffic
+      container: static-frontend
+      port: 80
+      host-port: 80
+      publish: true
+      protocol: tcp
+  connections: {}
+  variables: {}
+
+stack:
+  defines: group
+  members:
+    - pink/static-frontend


### PR DESCRIPTION
# PR Description: Containerization and Deployment Configuration for Static Frontend

## Changes Made

- **Dockerfile Creation**: I created a `Dockerfile.static-frontend` to containerize the static frontend application. This Dockerfile uses `nginx:alpine` as the base image to serve the static files and exposes port 80 for HTTP traffic.
- **Monk.io Configuration**: Added a `monk.yaml` file to define the Monk.io deployment configuration and a `MANIFEST` file to list all files containing Monk configurations.
- **Service Analysis**: Confirmed that the repository contains a static frontend website with no backend services or databases. The application is a template for HTML mockups with a gulp build process for development purposes.
- **Container Verification**: Verified the container startup logs and confirmed that the nginx server started correctly without any errors. The Dockerfile is correctly set up to serve the static frontend.

## Instructions for Continuation

- **Merge PR**: The application is ready for re-deployment. Merging this PR will ensure that the application is containerized and can be re-deployed on each subsequent push.
- **No Further Configuration**: There are no backend services, databases, or environment variables required for this static frontend service. No further action is required at this point.

## Notes

- The static frontend service does not require any connections to other services within the repository.
- The service exposes port 80 for HTTP traffic, and no additional ports or environment variables are needed.
- The Dockerfile and Monk.io configuration are complete and do not require additional adjustments.